### PR TITLE
feat: Import dbt schedules and assign to rj_sme__dbt_transform__flow

### DIFF
--- a/pipelines/dbt_transform/flows.py
+++ b/pipelines/dbt_transform/flows.py
@@ -11,6 +11,10 @@ from prefeitura_rio.pipelines_utils.state_handlers import handler_inject_bd_cred
 
 from pipelines.constants import constants
 
+from pipelines.dbt_transform.schedules import (
+    dbt_schedules,
+)
+
 rj_sme__dbt_transform__flow = deepcopy(templates__dbt_transform__flow)
 rj_sme__dbt_transform__flow.state_handlers = [handler_inject_bd_credentials]
 rj_sme__dbt_transform__flow.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
@@ -28,5 +32,7 @@ rj_sme__dbt_transform__flow = set_default_parameters(
         "bigquery_project": constants.RJ_SME_AGENT_LABEL.value,
     },
 )
+
+rj_sme__dbt_transform__flow.schedule = dbt_schedules
 
 # COMMENT TO TRIGGER.

--- a/pipelines/dbt_transform/flows.py
+++ b/pipelines/dbt_transform/flows.py
@@ -10,10 +10,7 @@ from prefeitura_rio.pipelines_utils.prefect import set_default_parameters
 from prefeitura_rio.pipelines_utils.state_handlers import handler_inject_bd_credentials
 
 from pipelines.constants import constants
-
-from pipelines.dbt_transform.schedules import (
-    dbt_schedules,
-)
+from pipelines.dbt_transform.schedules import dbt_schedules
 
 rj_sme__dbt_transform__flow = deepcopy(templates__dbt_transform__flow)
 rj_sme__dbt_transform__flow.state_handlers = [handler_inject_bd_credentials]


### PR DESCRIPTION
This pull request includes changes to the `pipelines/dbt_transform/flows.py` file to incorporate scheduling functionality. The most important changes include importing the `dbt_schedules` from `pipelines.dbt_transform.schedules` and setting the schedule for the `rj_sme__dbt_transform__flow`.

Enhancements to scheduling:

* [`pipelines/dbt_transform/flows.py`](diffhunk://#diff-4b1c9c9ba836c248c2af2064bef75a6a1f6e950969579acba63661edde9eb5c8R14-R17): Added import for `dbt_schedules` from `pipelines.dbt_transform.schedules`.
* [`pipelines/dbt_transform/flows.py`](diffhunk://#diff-4b1c9c9ba836c248c2af2064bef75a6a1f6e950969579acba63661edde9eb5c8R36-R37): Set the `rj_sme__dbt_transform__flow.schedule` to use `dbt_schedules`.