### PR TITLE
refactor: Remove unused daily parameter for source freshness

### DIFF
--- a/pipelines/dbt_transform/schedules.py
+++ b/pipelines/dbt_transform/schedules.py
@@ -26,11 +26,7 @@ daily_parameters = [
         **common_parameters,
         "command": "build",
         "select": "tag:daily",
-    },
-    {
-        **common_parameters,
-        "command": "source freshness",
-    },
+    }
 ]
 
 weekly_parameters = [


### PR DESCRIPTION
This pull request includes a change to the `pipelines/dbt_transform/schedules.py` file. The change removes a redundant schedule configuration for the "source freshness" command, simplifying the daily schedule parameters.

Changes to schedule configurations:

* [`pipelines/dbt_transform/schedules.py`](diffhunk://#diff-86c414f144f3c95c37a2379acf562147c4a650116ce295e022216b8bef100f57L29-R29): Removed the redundant "source freshness" command from the daily schedule parameters.