### PR TITLE
refactor: Remove unused column from attendance frequency SQL query to…

### DIFF
--- a/queries/models/educacao_basica_frequencia/educacao_basica_frequencia__vw_alunos_frequencia_acumulada_dias_letivos.sql
+++ b/queries/models/educacao_basica_frequencia/educacao_basica_frequencia__vw_alunos_frequencia_acumulada_dias_letivos.sql
@@ -35,7 +35,6 @@ WITH frequencia_acumulada AS (
         -- Subquery para calcular faltas do COC atual
         SELECT
             MTU.alu_id,
-            MTU.mtu_id,
             TAU.id_tipo_calendario,
             SUM(TAA.faltas_disciplina_dia) AS num_faltas
         FROM {{ ref('brutos_gestao_escolar__turma_aula_aluno') }} TAA
@@ -77,7 +76,6 @@ WITH frequencia_acumulada AS (
             AND TJF.tjf_abonaFalta IS NULL
         GROUP BY
             MTU.alu_id,
-            MTU.mtu_id,
             TAU.id_tipo_calendario
     ) SQ_FALTAS
         ON NUM.alu_id = SQ_FALTAS.alu_id


### PR DESCRIPTION
This pull request makes a small adjustment to the SQL query in `educacao_basica_frequencia__vw_alunos_frequencia_acumulada_dias_letivos.sql` by removing the `MTU.mtu_id` column from both the SELECT and GROUP BY clauses in the `frequencia_acumulada` subquery. This change simplifies the query by eliminating an unused column.