### PR TITLE
feat: Add new evaluation model and integrate it into attendance frequ…

### DIFF
--- a/queries/models/brutos_gestao_escolar/_brutos_gestao_escolar__schema.yml
+++ b/queries/models/brutos_gestao_escolar/_brutos_gestao_escolar__schema.yml
@@ -331,3 +331,4 @@ models :
   - name: brutos_gestao_escolar__aluno_justificativa_falta
   - name: brutos_gestao_escolar__tipo_justificativa_falta
   - name: brutos_gestao_escolar__aluno_historico_completo
+  - name: brutos_gestao_escolar__avaliacao

--- a/queries/models/brutos_gestao_escolar/_brutos_gestao_escolar__source.yml
+++ b/queries/models/brutos_gestao_escolar/_brutos_gestao_escolar__source.yml
@@ -25,4 +25,5 @@ sources:
       - name: ACA_TipoJustificativaFalta
       - name: VW_BI_Aluno
       - name: VW_BI_Aluno_Todos_Os_Anos
+      - name: ACA_Avaliacao
 

--- a/queries/models/brutos_gestao_escolar/brutos_gestao_escolar__avaliacao.sql
+++ b/queries/models/brutos_gestao_escolar/brutos_gestao_escolar__avaliacao.sql
@@ -1,0 +1,44 @@
+{{ config(alias='avaliacao', schema='brutos_gestao_escolar') }}
+
+with source as (
+    select * from {{ source('brutos_gestao_escolar_staging', 'ACA_Avaliacao') }}
+),
+
+renamed as (
+    select
+        {{ adapter.quote("_airbyte_extracted_at") }} AS loaded_at,
+        SAFE_CAST({{ adapter.quote("fav_id") }} AS STRING) AS {{ adapter.quote("fav_id") }},
+        SAFE_CAST({{ adapter.quote("ava_id") }} AS STRING) AS {{ adapter.quote("ava_id") }},
+        {{ adapter.quote("ava_nome") }},
+        {{ adapter.quote("ava_tipo") }},
+        SAFE_CAST({{ adapter.quote("tpc_id") }} AS STRING) AS {{ adapter.quote("tpc_id") }},
+        {{ adapter.quote("ava_ordemPeriodo") }},
+        {{ adapter.quote("ava_apareceBoletim") }},
+        {{ adapter.quote("ava_situacao") }},
+        {{ adapter.quote("ava_dataCriacao") }},
+        {{ adapter.quote("ava_dataAlteracao") }},
+        {{ adapter.quote("ava_conceitoGlobalObrigatorio") }},
+        {{ adapter.quote("ava_baseadaConceitoGlobal") }},
+        {{ adapter.quote("ava_baseadaNotaDisciplina") }},
+        {{ adapter.quote("ava_baseadaAvaliacaoAdicional") }},
+        {{ adapter.quote("ava_mostraBoletimConceitoGlobalNota") }},
+        {{ adapter.quote("ava_mostraBoletimConceitoGlobalFrequencia") }},
+        {{ adapter.quote("ava_mostraBoletimConceitoGlobalAvaliacaoAdicional") }},
+        {{ adapter.quote("ava_mostraBoletimDisciplinaNota") }},
+        {{ adapter.quote("ava_mostraBoletimDisciplinaFrequencia") }},
+        {{ adapter.quote("ava_recFinalConceitoMaximoAprovacao") }},
+        {{ adapter.quote("ava_recFinalConceitoGlobalMinimoNaoAtingido") }},
+        {{ adapter.quote("ava_recFinalFrequenciaMinimaFinalNaoAtingida") }},
+        {{ adapter.quote("ava_recFinalNotaDisciplinaApenasConceitoGlobalNaoAtingido") }},
+        {{ adapter.quote("ava_disciplinaObrigatoria") }},
+        {{ adapter.quote("ava_exibeNaoAvaliados") }},
+        {{ adapter.quote("ava_exibeSemProfessor") }},
+        {{ adapter.quote("ava_exibeObservacaoDisciplina") }},
+        {{ adapter.quote("ava_exibeObservacaoConselhoPedagogico") }},
+        {{ adapter.quote("ava_exibeFrequencia") }},
+        {{ adapter.quote("ava_exibeNotaPosConselho") }},
+        {{ adapter.quote("ava_conceitoGlobalObrigatorioFrequencia") }}
+    from source
+)
+
+select * from renamed

--- a/queries/models/educacao_basica_frequencia/educacao_basica_frequencia__vw_alunos_frequencia_acumulada_dias_letivos.sql
+++ b/queries/models/educacao_basica_frequencia/educacao_basica_frequencia__vw_alunos_frequencia_acumulada_dias_letivos.sql
@@ -12,6 +12,9 @@ WITH frequencia_acumulada AS (
         AAT.aat_numeroAulas AS numeroAulas,
         AAT.aat_numeroFaltas AS numeroFaltas
     FROM {{ ref('brutos_gestao_escolar__aluno_avaliacao_turma') }} AAT
+    INNER JOIN {{ ref('brutos_gestao_escolar__avaliacao') }} AVA
+        ON AAT.fav_id = AVA.fav_id
+        AND AAT.ava_id = AVA.ava_id
     INNER JOIN {{ ref('brutos_gestao_escolar__tur_turma') }} TUR
         ON AAT.tur_id = TUR.tur_id
         AND TUR.tur_situacao IN (1,5)
@@ -20,6 +23,7 @@ WITH frequencia_acumulada AS (
         AND CAL.cal_ano = EXTRACT(YEAR FROM CURRENT_DATE())
     INNER JOIN {{ ref('brutos_gestao_escolar__calendario_periodo') }} CAP
         ON TUR.cal_id = CAP.cal_id
+        AND CAP.cap_id = AVA.tpc_id
         AND CAP.cap_dataFim < CURRENT_DATE()
 
     UNION ALL


### PR DESCRIPTION
This pull request introduces a new model, `brutos_gestao_escolar__avaliacao`, to the data pipeline for managing school evaluation data. It includes changes to schema definitions, source references, SQL logic for the new model, and updates to existing queries to integrate the new model.

### Addition of the `brutos_gestao_escolar__avaliacao` model:

* **Schema definition update**: Added `brutos_gestao_escolar__avaliacao` to the `models` section of `_brutos_gestao_escolar__schema.yml`.
* **Source reference update**: Added `ACA_Avaliacao` to the `sources` section of `_brutos_gestao_escolar__source.yml`.
* **New SQL model**: Added `brutos_gestao_escolar__avaliacao.sql` to define the logic for the `brutos_gestao_escolar__avaliacao` model. This includes selecting and renaming fields from the source table `ACA_Avaliacao` and casting certain fields to specific types.

### Integration of the new model into existing queries:

* **Reference in frequency query**: Updated `educacao_basica_frequencia__vw_alunos_frequencia_acumulada_dias_letivos.sql` to join with `brutos_gestao_escolar__avaliacao` using `fav_id` and `ava_id`.
* **Calendar period condition**: Added a condition to join `brutos_gestao_escolar__calendario_periodo` with `brutos_gestao_escolar__avaliacao` using `tpc_id` in the same frequency query.